### PR TITLE
Add djangocms-versioning support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,9 @@ Installation & Updates
 Please head over to our `documentation`_ for all the details on how to install,
 configure and use Aldryn News & Blog.
 
+The application supports ``djangocms-versioning`` so articles can be drafted,
+reviewed and published through the standard versioning workflow.
+
 You can also find instructions on `how to upgrade`_ from earlier versions.
 
 .. _documentation: http://aldryn-newsblog.readthedocs.io/en/latest/

--- a/aldryn_newsblog/cms_config.py
+++ b/aldryn_newsblog/cms_config.py
@@ -1,0 +1,17 @@
+from cms.app_base import CMSAppConfig
+
+from djangocms_versioning.datastructures import VersionableItem, default_copy
+
+from .models import Article
+
+
+class NewsBlogVersioningConfig(CMSAppConfig):
+    djangocms_versioning_enabled = True
+    versioning = [
+        VersionableItem(
+            content_model=Article.translations.model,
+            grouper_field_name="master",
+            extra_grouping_fields=["language_code"],
+            copy_function=default_copy,
+        )
+    ]

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ REQUIREMENTS = [
     'djangocms-aldryn-search~=3.0',
     'djangocms-aldryn-translation-tools~=1.0',
     'django-haystack~=3.3',
+    'djangocms-versioning~=2.3',
     'backport-collections~=0.1',
     'djangocms-text~=0.8',
     'django-taggit~=6.1',


### PR DESCRIPTION
## Summary
- integrate djangocms-versioning with new CMS config
- depend on djangocms-versioning
- mention versioning in README

## Testing
- `tox -e flake8`
- `tox -e isort`

------
https://chatgpt.com/codex/tasks/task_e_684e4a33268c832eaef521c1f346d95a