### PR TITLE
Fix naive datetime warnings

### DIFF
--- a/aldryn_newsblog/tests/__init__.py
+++ b/aldryn_newsblog/tests/__init__.py
@@ -18,6 +18,7 @@ from cms.exceptions import AppAlreadyRegistered
 from cms.models import PageContent
 from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
+from django.utils import timezone
 
 from aldryn_categories.models import Category
 from aldryn_people.models import Person
@@ -202,6 +203,8 @@ class NewsBlogTestsMixin:
         if is_published:
             version.publish(_owner)
         if publishing_date:
+            if timezone.is_naive(publishing_date):
+                publishing_date = timezone.make_aware(publishing_date, timezone.utc)
             version.created = publishing_date
             version.save(update_fields=['created'])
 

--- a/aldryn_newsblog/views.py
+++ b/aldryn_newsblog/views.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from django.utils import timezone
 
 from django.db.models import Q
 from django.http import (
@@ -567,6 +568,8 @@ class DateRangeArticleList(ArticleListBase):
 class YearArticleList(DateRangeArticleList):
     def _daterange_from_kwargs(self, kwargs):
         date_from = datetime(int(kwargs['year']), 1, 1)
+        if timezone.is_naive(date_from):
+            date_from = timezone.make_aware(date_from)
         date_to = date_from + relativedelta(years=1)
         return date_from, date_to
 
@@ -574,6 +577,8 @@ class YearArticleList(DateRangeArticleList):
 class MonthArticleList(DateRangeArticleList):
     def _daterange_from_kwargs(self, kwargs):
         date_from = datetime(int(kwargs['year']), int(kwargs['month']), 1)
+        if timezone.is_naive(date_from):
+            date_from = timezone.make_aware(date_from)
         date_to = date_from + relativedelta(months=1)
         return date_from, date_to
 
@@ -582,5 +587,7 @@ class DayArticleList(DateRangeArticleList):
     def _daterange_from_kwargs(self, kwargs):
         date_from = datetime(
             int(kwargs['year']), int(kwargs['month']), int(kwargs['day']))
+        if timezone.is_naive(date_from):
+            date_from = timezone.make_aware(date_from)
         date_to = date_from + relativedelta(days=1)
         return date_from, date_to


### PR DESCRIPTION
## Summary
- ensure `create_article` sets version dates with timezone awareness
- make date range filters timezone-aware to avoid warnings

## Testing
- `python custom_manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68656cef965c832ebfaedb3ae9b95b33