### PR TITLE
Add article versioning via djangocms-versioning

### DIFF
--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -14,6 +14,14 @@ from aldryn_translation_tools.admin import AllTranslationsMixin
 from parler.admin import TranslatableAdmin
 from parler.forms import TranslatableModelForm
 
+try:
+    from djangocms_versioning.admin import (
+        ExtendedIndicatorVersionAdminMixin,
+    )
+    VersioningMixin = ExtendedIndicatorVersionAdminMixin
+except Exception:  # pragma: no cover - fallback when versioning not installed
+    VersioningMixin = object
+
 from . import models
 
 
@@ -101,6 +109,7 @@ class ArticleAdminForm(TranslatableModelForm):
 
 
 class ArticleAdmin(
+    VersioningMixin,
     AllTranslationsMixin,
     PlaceholderAdminMixin,
     FrontendEditableAdminMixin,

--- a/aldryn_newsblog/cms_config.py
+++ b/aldryn_newsblog/cms_config.py
@@ -1,0 +1,22 @@
+from cms.app_base import CMSAppConfig
+from django.conf import settings
+
+from aldryn_newsblog.models import Article
+
+
+class NewsBlogCMSConfig(CMSAppConfig):
+    djangocms_versioning_enabled = getattr(
+        settings, "ALDRYN_NEWSBLOG_VERSIONING_ENABLED", False
+    )
+    cms_enabled = True
+
+    if djangocms_versioning_enabled:
+        from djangocms_versioning.datastructures import VersionableItem, default_copy
+
+        versioning = [
+            VersionableItem(
+                content_model=Article,
+                grouper_field_name="id",
+                copy_function=default_copy,
+            )
+        ]

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ REQUIREMENTS = [
     'lxml~=5.4',
     'lxml_html_clean~=0.4',
     'looseversion~=1.3',
+    'djangocms-versioning',
 ]
 
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
## Summary
- integrate djangocms-versioning
- register a CMS config with a `VersionableItem` for Article (disabled by default)
- apply versioning mixin in Article admin when available

## Testing
- `flake8 aldryn_newsblog/admin.py aldryn_newsblog/cms_config.py setup.py`
- `python test_settings.py --version`
- `python test_settings.py aldryn_newsblog.tests.test_admin --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68658ddbb228832e9556fc14fe210a65