### PR TITLE
Add article versioning via djangocms-versioning

### DIFF
--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -14,6 +14,14 @@ from aldryn_translation_tools.admin import AllTranslationsMixin
 from parler.admin import TranslatableAdmin
 from parler.forms import TranslatableModelForm
 
+try:
+    from djangocms_versioning.admin import (
+        ExtendedIndicatorVersionAdminMixin,
+    )
+    VersioningMixin = ExtendedIndicatorVersionAdminMixin
+except Exception:  # pragma: no cover - fallback when versioning not installed
+    VersioningMixin = object
+
 from . import models
 
 
@@ -101,6 +109,7 @@ class ArticleAdminForm(TranslatableModelForm):
 
 
 class ArticleAdmin(
+    VersioningMixin,
     AllTranslationsMixin,
     PlaceholderAdminMixin,
     FrontendEditableAdminMixin,

--- a/aldryn_newsblog/cms_config.py
+++ b/aldryn_newsblog/cms_config.py
@@ -1,0 +1,22 @@
+from cms.app_base import CMSAppConfig
+from django.conf import settings
+
+from aldryn_newsblog.models import Article
+
+
+class NewsBlogCMSConfig(CMSAppConfig):
+    djangocms_versioning_enabled = getattr(
+        settings, "ALDRYN_NEWSBLOG_VERSIONING_ENABLED", False
+    )
+    cms_enabled = True
+
+    if djangocms_versioning_enabled:
+        from djangocms_versioning.datastructures import VersionableItem, default_copy
+
+        versioning = [
+            VersionableItem(
+                content_model=Article,
+                grouper_field_name="id",
+                copy_function=default_copy,
+            )
+        ]

--- a/aldryn_newsblog/cms_wizards.py
+++ b/aldryn_newsblog/cms_wizards.py
@@ -89,12 +89,13 @@ class CreateNewsBlogArticleForm(BaseFormMixin, TranslatableModelForm):
 
     def save(self, commit=True):
         article = super().save(commit=False)
-        article.owner = self.user
+        user = getattr(self, "user", getattr(self, "_request", None) and self._request.user)
+        article.owner = user
         article.save()
 
         # If 'content' field has value, create a TextPlugin with same and add it to the PlaceholderField
         content = clean_html(self.cleaned_data.get('content', ''), False)
-        if content and permissions.has_plugin_permission(self.user, 'TextPlugin', 'add'):
+        if content and permissions.has_plugin_permission(user, 'TextPlugin', 'add'):
             add_plugin(
                 placeholder=article.content,
                 plugin_type='TextPlugin',

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ REQUIREMENTS = [
     'lxml~=5.4',
     'lxml_html_clean~=0.4',
     'looseversion~=1.3',
+    'djangocms-versioning',
 ]
 
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/test_settings.py
+++ b/test_settings.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 from django import get_version
+from django.utils import encoding as django_encoding
 
 from cms import __version__ as cms_string_version
 
@@ -14,6 +15,18 @@ from looseversion import LooseVersion
 
 django_version = LooseVersion(get_version())
 cms_version = LooseVersion(cms_string_version)
+
+# Compatibility for packages still importing force_text from Django 5
+if not hasattr(django_encoding, "force_text"):
+    django_encoding.force_text = django_encoding.force_str
+
+try:
+    import importlib
+    importlib.import_module("django.utils.six")  # pragma: no cover - used by old libs
+except Exception:  # pragma: no cover - fallback for Django>=3
+    import six
+    sys.modules["django.utils.six"] = six
+    sys.modules["django.utils.six.moves"] = six.moves
 
 HELPER_SETTINGS = {
     'TIME_ZONE': 'Europe/Zurich',


### PR DESCRIPTION
## Summary
- integrate djangocms-versioning
- register a CMS config with a `VersionableItem` for Article (disabled by default)
- apply versioning mixin in Article admin when available
- avoid missing user errors in the article creation wizard
- alias `force_text` & `django.utils.six` in test settings for Django 5

## Testing
- `flake8 aldryn_newsblog/cms_wizards.py aldryn_newsblog/admin.py aldryn_newsblog/cms_config.py setup.py test_settings.py`
- `python test_settings.py --version`

------
https://chatgpt.com/codex/tasks/task_e_68658ddbb228832e9556fc14fe210a65