### PR TITLE
Fix admin article creation

### DIFF
--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -193,8 +193,7 @@ class ArticleContentAdmin(
     fieldsets = (
         (None, {
             'fields': (
-                # 'article_grouper',  # Should NOT be editable here; it's fixed for a version.
-                #                        ExtendedVersionAdminMixin handles this link.
+                'article_grouper',
                 'title',
                 'is_featured',
                 'lead_in',
@@ -221,6 +220,8 @@ class ArticleContentAdmin(
         }),
     )
     filter_horizontal = ['categories', 'related']
+    # Allow filtering ArticleContent by the app_config of its grouper
+    list_filter = ['article_grouper__app_config']
 
     def get_view_on_site_url(self, obj=None) -> Optional[str]:
         if obj is not None:


### PR DESCRIPTION
## Summary
- show `article_grouper` in ArticleContent admin fieldset
- allow filtering ArticleContent by `app_config`

## Testing
- `pip install -q -r test_requirements.txt`
- `pytest aldryn_newsblog/tests/test_admin.py -k test_add_article_via_admin -q` *(fails: settings not configured)*


------
https://chatgpt.com/codex/tasks/task_e_6866a3b4272c832e993d6edee2051631